### PR TITLE
ci: update VS Code extension dispatch target to VSCodeMCPSeedance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,6 @@ jobs:
           curl -s -X POST \
             -H "Authorization: token ${{ secrets.VSCODE_MCP_DISPATCH_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/AceDataCloud/VSCodeMCP/dispatches" \
+            "https://api.github.com/repos/AceDataCloud/VSCodeMCPSeedance/dispatches" \
             -d '{"event_type":"mcp-updated","client_payload":{"source":"${{ github.repository }}","version":"${{ needs.build.outputs.version }}"}}'
-          echo "Triggered VSCodeMCP extension rebuild"
+          echo "Triggered VSCodeMCPSeedance extension rebuild"


### PR DESCRIPTION
Updates the cross-repo dispatch target from the combined `VSCodeMCP` repo to the individual `VSCodeMCPSeedance` extension repo.