### PR TITLE
fix: revert endpoint path from /mc back to /mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Generate AI videos directly from Claude, VS Code, or any MCP-compatible client.
 
 AceDataCloud hosts a managed MCP server — **no local installation required**.
 
-**Endpoint:** `https://seedance.mcp.acedata.cloud/mc`
+**Endpoint:** `https://seedance.mcp.acedata.cloud/mcp`
 
 All requests require a Bearer token. Use the API token from Step 1.
 
@@ -45,7 +45,7 @@ All requests require a Bearer token. Use the API token from Step 1.
 Connect directly on [Claude.ai](https://claude.ai) with OAuth — **no API token needed**:
 
 1. Go to Claude.ai **Settings → Integrations → Add More**
-2. Enter the server URL: `https://seedance.mcp.acedata.cloud/mc`
+2. Enter the server URL: `https://seedance.mcp.acedata.cloud/mcp`
 3. Complete the OAuth login flow
 4. Start using the tools in your conversation
 
@@ -58,7 +58,7 @@ Add to your config (`~/Library/Application Support/Claude/claude_desktop_config.
   "mcpServers": {
     "seedance": {
       "type": "streamable-http",
-      "url": "https://seedance.mcp.acedata.cloud/mc",
+      "url": "https://seedance.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -76,7 +76,7 @@ Add to your MCP config (`.cursor/mcp.json` or `.windsurf/mcp.json`):
   "mcpServers": {
     "seedance": {
       "type": "streamable-http",
-      "url": "https://seedance.mcp.acedata.cloud/mc",
+      "url": "https://seedance.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -94,7 +94,7 @@ Add to your VS Code MCP config (`.vscode/mcp.json`):
   "servers": {
     "seedance": {
       "type": "streamable-http",
-      "url": "https://seedance.mcp.acedata.cloud/mc",
+      "url": "https://seedance.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -115,7 +115,7 @@ Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.c
 {
   "mcpServers": {
     "seedance": {
-      "url": "https://seedance.mcp.acedata.cloud/mc",
+      "url": "https://seedance.mcp.acedata.cloud/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -131,7 +131,7 @@ Or install the [Ace Data Cloud MCP extension](https://marketplace.visualstudio.c
 curl https://seedance.mcp.acedata.cloud/health
 
 # MCP initialize
-curl -X POST https://seedance.mcp.acedata.cloud/mc \
+curl -X POST https://seedance.mcp.acedata.cloud/mcp \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer YOUR_API_TOKEN" \

--- a/main.py
+++ b/main.py
@@ -217,7 +217,7 @@ Environment Variables:
 
             mcp.settings.stateless_http = True
             mcp.settings.json_response = True
-            mcp.settings.streamable_http_path = "/mc"
+            mcp.settings.streamable_http_path = "/mcp"
 
             # Build routes
             routes: list[Route | Mount] = [


### PR DESCRIPTION
Revert streamable HTTP path to /mcp and update README.